### PR TITLE
fix: ondismiss return type updated

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export interface RazorpayOptions {
     escape?: boolean;
     handleback?: boolean;
     confirm_close?: boolean;
-    ondismiss?: Function;
+    ondismiss?: () => void;
     animation?: boolean;
   };
   subscription_id?: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ export interface RazorpayOptions {
     escape?: boolean;
     handleback?: boolean;
     confirm_close?: boolean;
-    ondismiss?: boolean;
+    ondismiss?: Function;
     animation?: boolean;
   };
   subscription_id?: string;


### PR DESCRIPTION
As per Razorpay official documentation, ondismiss is a function [Documentation Link](https://razorpay.com/docs/payments/payment-gateway/web-integration/standard/build-integration#configure-payment-methods-optional)